### PR TITLE
Changes to use IDH linkages between SHA and KCHA

### DIFF
--- a/etl/db_loader/main_pha_load.R
+++ b/etl/db_loader/main_pha_load.R
@@ -22,6 +22,7 @@ library(tidyverse) # Manipulate data
 library(lubridate) # Work with dates
 library(odbc) # Read to and write from SQL
 library(configr) # Read in YAML files
+library(yaml) # Write YAML files
 library(glue) # Safely combine SQL code
 library(keyring) # Access stored credentials
 library(housing) # Has some functions specific to the PHA data
@@ -67,10 +68,10 @@ db_idh  <-  DBI::dbConnect(odbc::odbc(),
       if (dbExistsTable(db_hhsaw, DBI::Id(schema = "pha", table = "final_identities"))) {
         # First back up existing archive table
         if (dbExistsTable(db_hhsaw, DBI::Id(schema = "pha", table = "archive_identities"))) {
-          dbExecute(db_hhsaw, "EXEC sp_rename 'pha.archive_identities', 'archive_identities_bak'")
+          DBI::dbExecute(db_hhsaw, "EXEC sp_rename 'pha.archive_identities', 'archive_identities_bak'")
         }
         # Then move final table to archive
-        dbExecute(db_hhsaw, "SELECT * INTO pha.archive_identities FROM pha.final_identities")
+        DBI::dbExecute(db_hhsaw, "SELECT * INTO pha.archive_identities FROM pha.final_identities")
         
         # Check final table is backed up properly
         rows_archive <- as.integer(dbGetQuery(db_hhsaw, "SELECT COUNT (*) AS cnt FROM pha.archive_identities"))
@@ -81,26 +82,26 @@ db_idh  <-  DBI::dbConnect(odbc::odbc(),
         } else {
           message("pha.final_identities backed up properly, deleting archive backup (if it exists)")
           if (dbExistsTable(db_hhsaw, DBI::Id(schema = "pha", table = "archive_identities_bak"))) {
-            dbExecute(db_hhsaw, "DROP TABLE pha.archive_identities_bak")
+            DBI::dbExecute(db_hhsaw, "DROP TABLE pha.archive_identities_bak")
           }
           rm(rows_archive, rows_final)
         }
         
         # Then truncate final in preparation for loading stage
-        dbExecute(db_hhsaw, "DROP TABLE pha.final_identities")
+        DBI::dbExecute(db_hhsaw, "DROP TABLE pha.final_identities")
       }
       # Load from stage to final
-      dbExecute(db_hhsaw, "SELECT * INTO pha.final_identities FROM pha.stage_identities")
+      DBI::dbExecute(db_hhsaw, "SELECT * INTO pha.final_identities FROM pha.stage_identities")
   
   
   ## Final identity history ----
       if (dbExistsTable(db_hhsaw, DBI::Id(schema = "pha", table = "final_identities_history"))) {
         # First back up existing archive table
         if (dbExistsTable(db_hhsaw, DBI::Id(schema = "pha", table = "archive_identities_history"))) {
-          dbExecute(db_hhsaw, "EXEC sp_rename 'pha.archive_identities_history', 'archive_identities_history_bak'")
+          DBI::dbExecute(db_hhsaw, "EXEC sp_rename 'pha.archive_identities_history', 'archive_identities_history_bak'")
         }
         # Then move final table to archive
-        dbExecute(db_hhsaw, "SELECT * INTO pha.archive_identities_history FROM pha.final_identities_history")
+        DBI::dbExecute(db_hhsaw, "SELECT * INTO pha.archive_identities_history FROM pha.final_identities_history")
         
         # Check final table is backed up proper
         rows_archive <- as.integer(dbGetQuery(db_hhsaw, "SELECT COUNT (*) AS cnt FROM pha.archive_identities_history"))
@@ -111,16 +112,16 @@ db_idh  <-  DBI::dbConnect(odbc::odbc(),
         } else {
           message("pha.final_identities_history backed up, deleting archive backup (if it exists)")
           if (dbExistsTable(db_hhsaw, DBI::Id(schema = "pha", table = "archive_identities_history_bak"))) {
-            dbExecute(db_hhsaw, "DROP TABLE pha.archive_identities_history_bak")
+            DBI::dbExecute(db_hhsaw, "DROP TABLE pha.archive_identities_history_bak")
           }
           rm(rows_archive, rows_final)
         }
         
         # Then truncate final in preparation for loading stage
-        dbExecute(db_hhsaw, "DROP TABLE pha.final_identities_history")
+        DBI::dbExecute(db_hhsaw, "DROP TABLE pha.final_identities_history")
       }
       # Load from stage to final
-      dbExecute(db_hhsaw, "SELECT * INTO pha.final_identities_history FROM pha.stage_identities_history")
+      DBI::dbExecute(db_hhsaw, "SELECT * INTO pha.final_identities_history FROM pha.stage_identities_history")
   
   
 # MAKE DEMO EVER TABLE ----
@@ -140,9 +141,9 @@ db_idh  <-  DBI::dbConnect(odbc::odbc(),
   ## Final ----
   # Manually for now, fix later
   if (dbExistsTable(db_hhsaw, DBI::Id(schema = "pha", table = "final_demo"))) {
-    dbExecute(db_hhsaw, "DROP TABLE pha.final_demo")
+    DBI::dbExecute(db_hhsaw, "DROP TABLE pha.final_demo")
   }
-  dbExecute(db_hhsaw, "SELECT * INTO pha.final_demo FROM pha.stage_demo")
+  DBI::dbExecute(db_hhsaw, "SELECT * INTO pha.final_demo FROM pha.stage_demo")
   
   
 # MAKE TIMEVAR TABLE ----
@@ -163,9 +164,9 @@ db_idh  <-  DBI::dbConnect(odbc::odbc(),
   ## Final ----
     # Manually for now, fix later
     if (dbExistsTable(db_hhsaw, DBI::Id(schema = "pha", table = "final_timevar"))) {
-      dbExecute(db_hhsaw, "DROP TABLE pha.final_timevar")
+      DBI::dbExecute(db_hhsaw, "DROP TABLE pha.final_timevar")
     }
-    dbExecute(db_hhsaw, "SELECT * INTO pha.final_timevar FROM pha.stage_timevar")
+    DBI::dbExecute(db_hhsaw, "SELECT * INTO pha.final_timevar FROM pha.stage_timevar")
     
   
 # MAKE CALYEAR TABLE ----
@@ -184,9 +185,9 @@ db_idh  <-  DBI::dbConnect(odbc::odbc(),
   ## Final ----
     # Manually for now, fix later
     if (dbExistsTable(db_hhsaw, DBI::Id(schema = "pha", table = "final_calyear"))) {
-      dbExecute(db_hhsaw, "DROP TABLE pha.final_calyear")
+      DBI::dbExecute(db_hhsaw, "DROP TABLE pha.final_calyear")
     }
-    dbExecute(db_hhsaw, "SELECT * INTO pha.final_calyear FROM pha.stage_calyear")
+    DBI::dbExecute(db_hhsaw, "SELECT * INTO pha.final_calyear FROM pha.stage_calyear")
 
 # The end!
     message("\U0001f642 \U0001f308 \U0001f973")

--- a/etl/stage/load_stage_pha_demo.yaml
+++ b/etl/stage/load_stage_pha_demo.yaml
@@ -1,0 +1,34 @@
+datasource: PHA
+schema: pha
+table: stage_demo
+vars:
+  KCMASTER_ID: NVARCHAR(24)
+  gender_me: NVARCHAR(18)
+  gender_recent: NVARCHAR(16)
+  gender_female: BIT
+  gender_male: BIT
+  gender_female_t: NUMERIC(4,1)
+  gender_male_t: NUMERIC(4,1)
+  race_me: NVARCHAR(18)
+  race_eth_me: NVARCHAR(18)
+  race_recent: NVARCHAR(18)
+  race_eth_recent: NVARCHAR(18)
+  race_aian: BIT
+  race_asian: BIT
+  race_black: BIT
+  race_latino: BIT
+  race_nhpi: BIT
+  race_white: BIT
+  race_unk: BIT
+  race_eth_unk: BIT
+  race_aian_t: NUMERIC(4,1)
+  race_asian_t: NUMERIC(4,1)
+  race_black_t: NUMERIC(4,1)
+  race_nhpi_t: NUMERIC(4,1)
+  race_white_t: NUMERIC(4,1)
+  race_latino_t: NUMERIC(4,1)
+  dob: DATE
+  admit_date_sha: DATE
+  admit_date_kcha: DATE
+  admit_date_all: DATE
+  last_run: DATETIME

--- a/etl/stage/load_stage_pha_identities.R
+++ b/etl/stage/load_stage_pha_identities.R
@@ -1,7 +1,8 @@
-#### CODE TO COMBINE KING COUNTY HOUSING AUTHORITY AND SEATTLE HOUSING AUTHORITY IDENTITIES ----
-# Alastair Matheson, PHSKC (APDE)
-#
-# 2021-06
+#### CODE TO COMBINE KING COUNTY HOUSING AUTHORITY AND SEATTLE HOUSING AUTHORITY IDENTITIES USING IDH----
+# Alastair Matheson, PHSKC (APDE), 2021/06
+# Major revision by Danny Colombara, PHSKC (APDE), 2023/08
+# Now uses linkages identified by the integrated data hub rather than creating our own linkages in house
+# 
 
 ### Run from main_pha_load script
 # https://github.com/PHSKC-APDE/Housing/blob/main/claims_db/etl/db_loader/main_pha_load.R
@@ -28,734 +29,283 @@
     final_table <- "final_identities"
     
 # IMPORT IN DATA ----
-    # Get ID columns from stage_sha and stage_KCHA and final_identifies (if it exists)
-    if (dbExistsTable(db_hhsaw, name = DBI::Id(schema = final_schema, table = final_table))) {
-      namez_existing <- dbGetQuery(db_hhsaw, 
-                                   glue_sql("SELECT * FROM {`final_schema`}.{`final_table`}",
-                                            .con = db_hhsaw))
-      
-      namez <- dbGetQuery(
-        db_hhsaw,
-        glue_sql("SELECT c.*, d.present FROM
-                 (SELECT DISTINCT ssn, pha_id, lname, fname, mname, 
-                            dob, female, id_hash
-                          FROM {`from_schema`}.{DBI::SQL(paste0(from_table, 'kcha'))} a
-                          UNION
-                          SELECT DISTINCT ssn, pha_id, lname, fname, mname, 
-                            dob, female, id_hash
-                          FROM {`from_schema`}.{DBI::SQL(paste0(from_table, 'sha'))} b
-                 ) c
-                 LEFT JOIN
-                 (SELECT id_hash, 1 AS present FROM {`final_schema`}.{`final_table`}) d
-                 ON c.id_hash = d.id_hash
-                 WHERE present IS NULL",
-                 .con = db_hhsaw))
+    # Pull ID list from IDH so we do not have to replicate the matches----
+      idh.ids <- setDT(
+        odbc::dbGetQuery(conn = db_idh, 
+                         statement = "SELECT DISTINCT KCMASTER_ID, id_hash = PHOUSING_ID, 
+                                      ssn = SSN, lname = LAST_NAME_ORIG, 
+                                      fname = FIRST_NAME_ORIG, mname = MIDDLE_NAME_ORIG,
+                                      dob = DOB, GENDER
+                                      FROM [inthealth_dwhealth].[IDMatch].[IM_HISTORY_TABLE]
+                                      WHERE SOURCE_SYSTEM = 'PHA_CLIENT'"))
+      idh.ids[, female := fcase(GENDER == 'F', 1, 
+                                GENDER == 'M', 0)][, GENDER := NULL]
     
-      } else {
-      namez <- dbGetQuery(
-        db_hhsaw,
-        glue_sql("SELECT DISTINCT ssn, pha_id, lname, fname, mname, 
-                            dob, female, id_hash 
-                          FROM {`from_schema`}.{DBI::SQL(paste0(from_table, 'kcha'))} a
-                          UNION
-                          SELECT DISTINCT ssn, pha_id, lname, fname, mname, 
-                            dob, female, id_hash 
-                          FROM {`from_schema`}.{DBI::SQL(paste0(from_table, 'sha'))} b",
-                 .con = db_hhsaw))
-    }
-  
-  
-# FUNCTIONS (adapted from Carolina's code) ----
-    # From here: https://github.com/DCHS-PME/PMEtools/blob/main/R/idm_dedup.R
-    # pairs_input = Output from a RecordLinkage getPairs function
-    # df = The data frame that was fed into the matching process. 
-    #      Must have rowid and id_hash fields
-    # iteration = What match cycle this is (affects cluster ID suffix)
-    
-    match_process <- function(pairs_input, df, iteration) {
-      ### Attach ids for each individual pairwise link found ----
-      pairs <- pairs_input %>%
-        distinct(id1, id2) %>%
-        left_join(df, ., by = c(rowid = "id1"))
-      # In case the input was a data table, convert to data frame
-      # (otherwise the recursion breaks after 1 round)
-      pairs <- data.table::setDF(pairs)
-      
-      ### Roll up pair combinations ----
-      # self-join to consolidate all pair combinations for clusters with > 2 identities linked 
-      # roll up cluster id correctly with coalesce
-      # formula for how many other_pair2 records should exist for n number of matching records: 
-      #   (n*(n-1)/2) + 1 - e.g. 3 carolina johnsons will have 4  records (3*2/2+1)
-      remaining_dupes <- sum(!is.na(pairs$id2))
-      
-      # while loop self-joining pairs until no more open pairs remain
-      recursion_level <- 0
-      recursion_df <- pairs %>% rename(id2_recur0 = id2)
-      while (remaining_dupes > 0) {
-        recursion_level <- recursion_level + 1
-        print(paste0(remaining_dupes, " remaining duplicated rows. Starting recursion iteration ", recursion_level))
-        recursion_df <- pairs %>%
-          self_join_dups(base_df = ., iterate_df = recursion_df, iteration = recursion_level)
-        remaining_dupes <- sum(!is.na(recursion_df[ , paste0("id2_recur", recursion_level)]))
-      }
-      
-      # identify full list of id columns to coalesce after recursion
-      recurcols <- tidyselect::vars_select(names(recursion_df), matches("_recur\\d")) %>%
-        sort(decreasing = T)
-      coalesce_cols <- c(recurcols, "rowid")
-      coalesce_cols <- rlang::syms(coalesce_cols)
-      
-      # coalesce recursive id columns in sequence to generate single common cluster ID
-      pairsend <- recursion_df %>%
-        mutate(clusterid = coalesce(!!!coalesce_cols)) %>%
-        rename(id2 = id2_recur0) %>%
-        select(-contains("_recur")) %>%
-        distinct()
-      
-      # identify any unclosed cluster groups (open triangle problem), resulting in duplicated cluster
-      double_dups <- pairsend %>%
-        select(rowid, clusterid) %>%
-        distinct() %>%
-        group_by(rowid) %>%
-        filter(n() > 1) %>%
-        group_by(clusterid) %>%
-        mutate(row_min = min(rowid)) %>%
-        ungroup() %>%
-        rename(back_join_id = row_min) %>%
-        select(-rowid) %>%
-        distinct()
-      
-      
-      # collapse duplicate partial clusters to one cluster
-      # error checking to make sure that correct total clusters are maintained
-      if (nrow(double_dups) > 0) {
-        pairsend <- left_join(pairsend, double_dups, by = c(clusterid = "clusterid")) %>%
-          mutate(clusterid2 = coalesce(back_join_id, clusterid))
+    # Pull IDs from KCHA & SHA stage tables ----
+        kcha.ids <- setDT(
+          odbc::dbGetQuery(conn = db_hhsaw, 
+                           statement = paste0("SELECT DISTINCT kcha = agency, id_hash, kcha_id = pha_id
+                                              FROM [", from_schema, "].[", from_table, "kcha]")
+          ))
         
-        message("There are ", sum(pairsend$clusterid != pairsend$clusterid2), 
-                " mismatched clusterid/clusterid2 combos and at least ",
-                nrow(double_dups)*2, " expected")
+        sha.ids <-  setDT(
+          odbc::dbGetQuery(conn = db_hhsaw, 
+                           statement = paste0("SELECT DISTINCT sha = agency, id_hash, sha_id = pha_id
+                                              FROM [", from_schema, "].[", from_table,"sha]")
+          ))
         
-        pairsend <- pairsend %>%
-          mutate(clusterid = clusterid2) %>%
-          select(-clusterid2, -back_join_id)
-      }
-      
-      ### Add identifiers/unique ids for paired records ----
-      # overwrite the original pairs with the consolidated & informed dataframe
-      pairs_final <- df %>%
-        rename_all(~ paste0(., "_b")) %>%
-        left_join(pairsend, ., by = c(id2 = "rowid_b"))
-      
-      ### Take the union of all unique ids with their cluster ids ----
-      # (swinging links from _b cols to unioned rows, and taking distinct)
-      # create cluster index
-      cluster_index <- select(pairs_final, clusterid, id_hash = id_hash_b) %>%
-        drop_na() %>%
-        bind_rows(select(pairs_final, clusterid, id_hash)) %>%
-        distinct()
-      
-      ### Check that each personal id only in one cluster ----
-      n_pi_split <- pairs_final %>% 
-        group_by(id_hash) %>% 
-        filter(n_distinct(clusterid) > 1) %>%
-        n_distinct()
-      
-      if (n_pi_split) {
-        stop(glue::glue("Deduplication processing error: {nrow(n_pi_split)} ",
-                        "clients sorted into more than one cluster. ", 
-                        "This is an internal failure in the function and will require debugging. ", 
-                        "Talk to package maintainer)"))
-      }
-      
-      ### Report results ----
-      n_orig_ids <- df %>% select(id_hash) %>% n_distinct()
-      n_cluster_ids <- n_distinct(cluster_index$clusterid)
-      
-      message("Number of unique clients prior to deduplication: ", n_orig_ids, 
-              ". Number of deduplicated clients: ", n_cluster_ids)
-      
-      
-      ### Attach cluster IDS back to base file ----
-      output <- left_join(df, 
-                          # Set up iteration name
-                          rename(cluster_index, 
-                                 !!quo_name(paste0("clusterid_", iteration)) := clusterid), 
-                          by = "id_hash")
-      output
-    }
-    
-    
-    ## Helper functions specifically for client deduplication
-    #' Function for joining duplicated records to base pair, used in recursive deduplication
-    #' @param base_df The starting dataframe with initial duplicated pair ids
-    #' @param iterate_df The df with iterated rowid joins - what is continually updated during recursive pair closing
-    #' @param iteration Numeric counter indicating which recursion iteration the self-joining loop is on. Used for column name suffixes
-    self_join_dups <- function(base_df, iterate_df, iteration) {
-      joinby <- paste0("rowid_recur", iteration)
-      names(joinby) <- paste0("id2_recur", iteration-1)
-      
-      base_df %>%
-        select(rowid, id2) %>%
-        rename_all(~paste0(., "_recur", iteration)) %>%
-        left_join(iterate_df, ., by = joinby)
-    }
-    
-    
-    # This function creates a vector of unique IDs of any length
-    # id_n = how many unique IDs you want generated
-    # id_length = how long do you want the ID to get (too short and you'll be stuck in a loop)
-    id_nodups <- function(id_n, id_length, seed = 98104) {
-      set.seed(seed)
-      id_list <- stringi::stri_rand_strings(n = id_n, length = id_length, pattern = "[a-z0-9]")
-      
-      # If any IDs were duplicated (very unlikely), overwrite them with new IDs
-      iteration <- 1
-      while(any(duplicated(id_list)) & iteration <= 50) {
-        id_list[which(duplicated(id_list))] <- stringi::stri_rand_strings(n = sum(duplicated(id_list), na.rm = TRUE),
-                                                                          length = id_length,
-                                                                          pattern = "[a-z0-9]")
-        iteration <<- iteration + 1
-      }
-      
-      if (iteration == 50) {
-        stop("After 50 iterations there are still duplicate IDs. ",
-             "Either decrease id_n or increase id_length")
-      } else {
-        return(id_list)
-      }
-    }
-  
-  
-# SET UP DATA ----
-  ## Clean up names ----
-  # This has been moved to the stage_kcha/sha step so the id_hash remains consistent
-  
-  
-  ## Add in variables for matching ----
-    if (exists("namez_existing")) {
-      namez_use <- bind_rows(mutate(namez_existing, source = "final"), 
-                              mutate(namez, source = "new")) %>%
-        select(-present)
-    } else {
-      namez_use <- namez %>% mutate(source = "new")
-    }
-    
-    namez_use <- namez_use %>%
-      mutate(ssn_id = case_when(!is.na(ssn) ~ ssn,
-                                !is.na(pha_id) ~ pha_id,
-                                TRUE ~ NA_character_),
-             lname_phon = RecordLinkage::soundex(lname),
-             fname_phon = RecordLinkage::soundex(fname),
-             dob_y = lubridate::year(dob),
-             dob_m = lubridate::month(dob),
-             dob_d = as.numeric(lubridate::day(dob)),
-             rowid = row_number())
-  
-  
-# LINKAGE FIRST PASS: BLOCK ON SSN OR PHA ID ----
-  ## Run deduplication ----
-  # Blocking on SSN or PHA ID and string compare names
-  st <- Sys.time()
-  match_01 <- RecordLinkage::compare.dedup(
-    namez_use, 
-    blockfld = "ssn_id", 
-    strcmp = c("lname", "fname", "mname", "dob_y", "dob_m", "dob_d", "female"), 
-    exclude = c("ssn", "pha_id", "lname_phon", "fname_phon", "dob", "rowid", "id_hash", "id_kc_pha", "source"))
-  message("Pairwise comparisons complete. Total run time: ", round(Sys.time() - st, 2), " ", units(Sys.time()-st))
-  
-  summary(match_01)
-  
-  
-  ## Add weights and extract pairs ----
-  # Using EpiLink approach
-  match_01 <- epiWeights(match_01)
-  classify_01 <- epiClassify(match_01, threshold.upper = 0.6)
-  summary(classify_01)
-  pairs_01 <- getPairs(classify_01, single.rows = TRUE) %>%
-    mutate(across(contains("dob_"), ~ str_squish(.)),
-           across(contains("dob_"), ~ as.numeric(.)))
-  
-  ## Review output and select cutoff point(s) ----
-  pairs_01 %>% 
-    # Only keep matches with waitlist data in it
-    filter(!(source.1 == "final" & source.2 == "final")) %>%
-    # NON-JAN 1 SECTION
-    filter(!((dob_m.1 == "1" & dob_d.1 == "1") | (dob_m.2 == "1" & dob_d.2 == "1"))) %>%
-    # filter(Weight >= 0.7 & dob_y.1 != dob_y.2 & dob_m.1 == dob_m.2 & dob_d.1 == dob_d.2) %>%
-    # filter((Weight >= 0.4 & (dob_y.1 == dob_y.2 | abs(dob_y.1 - dob_y.2) == 100) & 
-    #           lname.1 == fname.2 & fname.1 == lname.2)) %>%
-    # filter(Weight >= 0.65 & dob_y.1 != dob_y.2 & lname.1 == fname.2 & fname.1 == lname.2) %>%
-    # filter(Weight >= 0.65 & dob_y.1 == dob_y.2 & (dob_m.1 != dob_m.2 | dob_d.1 != dob_d.2)) %>%
-    # filter(Weight >= 0.6 & dob_y.1 == dob_y.2 & dob_m.1 == dob_m.2 & dob_d.1 == dob_d.2) %>%
-    filter(Weight >= 0.74 & female.1 == female.2) %>%
-    # JAN 1 SECTION
-    # filter((dob_m.1 == "1" & dob_d.1 == "1") | (dob_m.2 == "1" & dob_d.2 == "1")) %>%
-    # filter(Weight >= 0.74 & dob_y.1 == dob_y.2) %>%
-    # filter(Weight >= 0.76 & dob_y.1 != dob_y.2) %>%
-    select(id1, ssn_id.1, lname.1, fname.1, mname.1, dob.1, female.1,
-                      id2, ssn_id.2, lname.2, fname.2, mname.2, dob.2, female.2,
-                      Weight) %>%
-    tail()
-  
-  
-  
-  
-  pairs_01_trunc <- pairs_01 %>%
-    # Only keep matches with waitlist data in it
-    filter(!(source.1 == "final" & source.2 == "final")) %>%
-    filter(
-      # SECTION FOR NON-JAN 1 BIRTH DATES
-      (!((dob_m.1 == "1" & dob_d.1 == "1") | (dob_m.2 == "1" & dob_d.2 == "1")) &
-         (
-           # Can take quite a low score when SSN matches, names are transposed, and YOB is the same or off by 100
-           (Weight >= 0.4 & (dob_y.1 == dob_y.2 | abs(dob_y.1 - dob_y.2) == 100) & 
-              lname.1 == fname.2 & fname.1 == lname.2) |
-             # Higher score when SSN matches, names are transposed, and YOB is different
-             (Weight >= 0.65 & dob_y.1 != dob_y.2 & lname.1 == fname.2 & fname.1 == lname.2) |
-             # Same month and day of birth but different year, no name checks
-             (Weight >= 0.72 & dob_y.1 != dob_y.2 & dob_m.1 == dob_m.2 & dob_d.1 == dob_d.2) |
-             # Transposed month and day of birth but no name checks
-             (Weight >= 0.63 & dob_y.1 == dob_y.2 & dob_m.1 == dob_d.2 & dob_d.1 == dob_m.2) |
-             # Mismatched gender but same YOB
-             (Weight >= 0.73 & dob_y.1 == dob_y.2 & female.1 != female.2) |
-             # Higher threshold if mismatched gender and YOB
-             (Weight >= 0.844 & dob_y.1 != dob_y.2 & female.1 != female.2) | 
-             # Catch everything else
-             (Weight >= 0.74 & female.1 == female.2)
-         )
-       ) |
-        # SECTION FOR WHEN THERE IS A JAN 1 BIRTH DATE INVOLVED
-        (Weight >= 0.75 & dob_m.1 == "1" & dob_d.1 == "1" & dob_m.2 == "1" & dob_d.2 == "1") |
-        (Weight >= 0.77 & (dob_m.1 == "1" & dob_d.1 == "1") | (dob_m.2 == "1" & dob_d.2 == "1")) |
-        # SECTION FOR MISSING GENDER AND/OR DOB
-        (
-          (is.na(female.1) | is.na(female.2) | is.na(dob_y.1) | is.na(dob_y.2)) &
-            (
-              # First names match
-              (Weight > 0.55 & fname.1 == fname.2) |
-                # Higher threshold first names don't match
-                (Weight > 0.64 & fname.1 != fname.2)
-            )
+    # Pull IDs from Waitlist and Exit data (to be sure all PHA data in IDH is accounted for) ----
+        wait.ids <- setDT(
+          odbc::dbGetQuery(conn = db_hhsaw, 
+                           statement = paste0("SELECT DISTINCT wait = 'WAIT', id_hash FROM [", from_schema, "].[", from_table,"pha_waitlist]")
+          ))
+        
+        exit.ids <- setDT(
+          odbc::dbGetQuery(conn = db_hhsaw, 
+                           statement = paste0("SELECT * FROM [", from_schema, "].[", from_table,"pha_exit]"))
         )
-      )
-  
-  
-  ## Collapse IDs ----
-  match_01_dedup <- match_process(pairs_input = pairs_01_trunc, 
-                                  df = namez_use, iteration = 1)
-  
-  
-  ## Error check ----
-  match_01_chk <- setDT(match_01_dedup %>% distinct(id_hash, clusterid_1))
-  match_01_chk[, cnt := .N, by = "id_hash"]
-  
-  if (max(match_01_chk$cnt) > 1) {
-    stop("Some id_hash values are associated with multiple clusterid_1 values. ",
-         "Check what went wrong.")
-  }
-  
-  
-  
-# LINKAGE SECOND PASS: BLOCK ON PHONETIC LNAME, FNAME AND DOB ----
-  ## Run deduplication ----
-  st <- Sys.time()
-  match_02 <- RecordLinkage::compare.dedup(
-    namez_use, 
-    blockfld = c("lname_phon", "fname_phon", "dob_y", "dob_m", "dob_d"), 
-    strcmp = c("ssn_id", "lname", "fname", "mname", "female"), 
-    exclude = c("ssn", "pha_id", "dob", "rowid", "id_hash"))
-  message("Pairwise comparisons complete. Total run time: ", round(Sys.time() - st, 2), " ", units(Sys.time()-st))
-  
-  summary(match_02)
-  
-  
-  ## Add weights and extract pairs ----
-  # Using EpiLink approach
-  match_02 <- epiWeights(match_02)
-  classify_02 <- epiClassify(match_02, threshold.upper = 0.6)
-  summary(classify_02)
-  pairs_02 <- getPairs(classify_02, single.rows = TRUE) %>%
-    mutate(across(contains("dob_"), ~ str_squish(.)),
-           across(contains("dob_"), ~ as.numeric(.)))
-  
-  ## Review output and select cutoff point(s) ----
-  pairs_02 %>% filter(Weight <= 0.8 & ssn_id.1 != ssn_id.2) %>% select(-contains("id_hash")) %>% head()
-  
-  pairs_02 %>% 
-    # Only keep matches with waitlist data in it
-    filter(!(source.1 == "final" & source.2 == "final")) %>%
-    # select(-contains("id_hash")) %>% 
-    filter(Weight >= 0.77) %>% 
-    filter(ssn_id.1 != ssn_id.2) %>%
-    filter(is.na(ssn.1) | is.na(ssn.2)) %>%
-    # filter(!is.na(ssn.1) & !is.na(ssn.2)) %>%
-    # filter(!(dob_m.1 == "1" & dob_d.1 == "1")) %>%
-    # filter(dob_m.1 == "1" & dob_d.1 == "1") %>%
-    tail()
-  
-  
-  pairs_02_trunc <- pairs_02 %>%
-    # Only keep matches with waitlist data in it
-    filter(!(source.1 == "final" & source.2 == "final")) %>%
-    filter(
-      # Matching SSN all have high weights and look good
-      ssn.1 == ssn.2 |
-        # SECTION WHERE SSNs DO NOT MATCH
-        (Weight >= 0.88 & ssn.1 != ssn.2 & !(dob_m.1 == "1" & dob_d.1 == "1")) |
-        (Weight >= 0.90 & ssn.1 != ssn.2 & dob_m.1 == "1" & dob_d.1 == "1") |
-        # SECTION WHERE AN SSN IS MISSING
-        ((is.na(ssn.1) | is.na(ssn.2)) &
-           (
-             (Weight >= 0.69 & !(dob_m.1 == "1" & dob_d.1 == "1")) |
-               (Weight >= 0.85 & dob_m.1 == "1" & dob_d.1 == "1")
-           )
-        )
-    )
-  
-  
-  ## Collapse IDs ----
-  match_02_dedup <- match_process(pairs_input = pairs_02_trunc, df = namez_use, iteration = 2) %>%
-    mutate(clusterid_2 = clusterid_2 + max(match_01_dedup$clusterid_1))
-  
-  ## Error check ----
-  match_02_chk <- setDT(match_02_dedup %>% distinct(id_hash, clusterid_2))
-  match_02_chk[, cnt := .N, by = "id_hash"]
-  
-  if (max(match_02_chk$cnt) > 1) {
-    stop("Some id_hash values are associated with multiple clusterid_2 values. ",
-         "Check what went wrong.")
-  }
-  
-  
-  
-# BRING MATCHING ROUNDS TOGETHER ----
-  # Use clusterid_1 as the starting point, find where one clusterid_2 value
-  # is associated with multiple clusterid_1 values, then take the min of the latter.
-  # Repeat using clusterid_2 until there is a 1:1 match between clusterid_1 and _2
-  
-  final_dedup <- function(iterate_dt, iteration) {
-    id_1_old <- paste0("id_1_recur", iteration-1)
-    id_1_min <- paste0("id_1_recur", iteration, "_min")
-    id_1_new <- paste0("id_1_recur", iteration)
-    id_1_cnt <- paste0("id_1_recur", iteration, "_cnt")
-    
-    id_2_old <- paste0("id_2_recur", iteration-1)
-    id_2_min <- paste0("id_2_recur", iteration, "_min")
-    id_2_new <- paste0("id_2_recur", iteration)
-    id_2_cnt <- paste0("id_2_recur", iteration, "_cnt")
-    
-    # First find the existing min value for IDs 1 and 2
-    iterate_dt[, (id_1_min) := min(get(id_1_old)), by = id_2_old]
-    iterate_dt[, (id_2_min) := min(get(id_2_old)), by = id_1_old]
-    # Then set the new ID 1 and 2 based on the min
-    iterate_dt[, (id_1_new) := min(get(id_1_min)), by = id_2_min]
-    iterate_dt[, (id_2_new) := min(get(id_2_min)), by = id_1_min]
-    
-    # Set up a count of remaining duplicates
-    iterate_dt[, clusterid_1_cnt := uniqueN(get(id_1_new)), by = id_2_new]
-    iterate_dt[, clusterid_2_cnt := uniqueN(get(id_2_new)), by = id_1_new]
-  }
-  
-  # Make joint data
-  ids_dedup <- setDT(full_join(select(match_01_dedup, id_hash, clusterid_1), 
-                               select(match_02_dedup, id_hash, clusterid_2),
-                               by = "id_hash"))
-  
-  # Count how much consolidation is required
-  ids_dedup[, clusterid_1_cnt := uniqueN(clusterid_1), by = "clusterid_2"]
-  ids_dedup[, clusterid_2_cnt := uniqueN(clusterid_2), by = "clusterid_1"]
-  remaining_dupes <- ids_dedup %>% count(clusterid_1_cnt, clusterid_2_cnt) %>%
-    filter(clusterid_1_cnt != clusterid_2_cnt) %>%
-    summarise(dups = sum(n))
-  remaining_dupes <- remaining_dupes$dups[1]
-  
-  if (remaining_dupes > 0) {
-    # Keep deduplicating until there are no more open triangles
-    recursion_level <- 0
-    recursion_dt <- copy(ids_dedup)
-    setnames(recursion_dt, old = c("clusterid_1", "clusterid_2"), new = c("id_1_recur0", "id_2_recur0"))
-    
-    while (remaining_dupes > 0) {
-      recursion_level <- recursion_level + 1
-      message(remaining_dupes, " remaining duplicated rows. Starting recursion iteration ", recursion_level)
+        exit.ids[, female := fcase(hh_gender == 'Female', 1, 
+                                   hh_gender == 'Male', 0)]
+        # need to create id_hash for exits
+        exit.ids[, id_hash := as.character(toupper(openssl::sha256(paste(stringr::str_replace_na(ssn, ''),
+                                                                         stringr::str_replace_na(pha_id, ''),
+                                                                         stringr::str_replace_na(lname, ''),
+                                                                         stringr::str_replace_na(fname, ''),
+                                                                         stringr::str_replace_na(mname, ''),
+                                                                         stringr::str_replace_na(dob, ''),
+                                                                         stringr::str_replace_na(female, ''),
+                                                                         sep = "|"))))]
+        exit.ids <- unique(exit.ids[, .(exit = 'EXIT', id_hash)])
       
-      recursion_dt <- final_dedup(iterate_dt = recursion_dt, iteration = recursion_level)
-      
-      # Check how many duplicates remain
-      remaining_dupes <- recursion_dt %>% count(clusterid_1_cnt, clusterid_2_cnt) %>%
-        filter(clusterid_1_cnt != clusterid_2_cnt) %>%
-        summarise(dups = sum(n))
-      remaining_dupes <- remaining_dupes$dups[1]
-    }
-    
-    # Get final ID to use
-    ids_dedup <- recursion_dt[, cluster_final := get(paste0("id_1_recur", recursion_level))]
-  } else {
-    ids_dedup[, cluster_final := clusterid_1]
-  }
+# MERGE IMPORTED TABLES TO LINK PHA `id_hash` TO KCMASTER_ID ----    
+    # Merge ID lists ----
+        linkages <- merge(idh.ids, 
+                          kcha.ids, 
+                          by = 'id_hash', 
+                          all = T)
+        
+        linkages <- merge(linkages, 
+                          sha.ids, 
+                          by = 'id_hash', 
+                          all = T)
+        
+        linkages <- merge(linkages, 
+                          wait.ids, 
+                          by = 'id_hash', 
+                          all.x = T, all.y = F)
+        
+        linkages <- merge(linkages, 
+                          exit.ids, 
+                          by = 'id_hash', 
+                          all.x = T, all.y = F)
+        
+        linkages[, agency := fcase(is.na(kcha) & is.na(sha), 'Neither', 
+                                   !is.na(kcha) & !is.na(sha), 'Both', 
+                                   !is.na(kcha) & is.na(sha), 'KCHA', 
+                                   is.na(kcha) & !is.na(sha), 'SHA')]
+        
+    # Check if all IDH SOURCE_SYSTEM = 'PHA_CLIENT' rows can be matched to PHA data ----
+        idh.check = linkages[is.na(wait) & is.na(exit), .(N = .N, freq = rads::round2(100*.N/nrow(linkages))), agency]
+        linkages[is.na(wait) & is.na(exit) & agency == 'Neither']
+        message(paste0("'Neither' PHA was was able to link to ~", idh.check[agency == 'Neither']$freq, 
+                       "% (n=", idh.check[agency == 'Neither']$N,") of the relevant IDH PHA data"))
+        
+    # Check if there are PHA data that are not in the IDH ----
+        kcha.missing <- linkages[is.na(KCMASTER_ID) & agency %in% c('KCHA', 'Both')]$id_hash
+        sha.missing <- linkages[is.na(KCMASTER_ID) & agency %in% c('SHA', 'Both')]$id_hash
+        pha.not.in.idh <- rbind(
+          setDT(odbc::dbGetQuery(conn = db_hhsaw, 
+                                 statement = glue::glue_sql("SELECT DISTINCT ssn, pha_id, lname, fname,
+                                         mname, dob, female, id_hash, agency = 'KCHA'
+                                         FROM [pha].[stage_kcha]
+                                         WHERE id_hash IN ({kcha.missing*})", .con = db_hhsaw))), 
+          setDT(odbc::dbGetQuery(conn = db_hhsaw, 
+                                 statement = glue::glue_sql("SELECT DISTINCT ssn, pha_id, lname, fname,
+                                         mname, dob, female, id_hash, agency = 'SHA'
+                                         FROM [pha].[stage_sha]
+                                         WHERE id_hash IN ({sha.missing*})", .con = db_hhsaw))))
+        pha.not.in.idh <- unique(pha.not.in.idh[id_hash %in% kcha.missing & id_hash %in% sha.missing, agency := 'Both'])
+ 
+        pha.check <- linkages[is.na(KCMASTER_ID), .N, agency]
+        message(paste0(sum(pha.check$N), " (", round(sum(pha.check$N) / nrow(linkages)),
+                       "%) of the PHA IDs could not be linked to the IDH"))
+        print(pha.check)
+        
+        message("Here are some IDs with SSN that are in the PHA data that did not link to the IDH")
+        pha.not.in.idh[!is.na(ssn)] 
+        
+        message("Here are the contents of the PHA-IDH linked table with these same SSN")
+        linkages[ssn %in% pha.not.in.idh[!is.na(ssn)]$ssn] 
   
-  # Keep only relevant columns
-  ids_dedup <- ids_dedup[, .(id_hash, cluster_final)]
-  
-  
-  ## Error check ----
-  ids_dedup_chk <- unique(ids_dedup[, c("id_hash", "cluster_final")])
-  ids_dedup_chk[, cnt_id := .N, by = "id_hash"]
-  ids_dedup_chk[, cnt_hash := .N, by = "cluster_final"]
-  # cnt_id should = 1 and cnt_hash should be >= 1
-  ids_dedup_chk %>% count(cnt_id, cnt_hash)
-  if (max(ids_dedup_chk$cnt_id) > 1) {
-    stop("There is more than one cluster ID for a given id_has. Investigate why.")
-  }
-  
-  
-  ## Make an alpha-numeric ID that will be stored in a table ----
-  new_ids_needed <- n_distinct(ids_dedup$cluster_final)
-  if (exists("namez_existing")) {
-    # Pull in existing IDs to make sure they are not repeated
-    ids_existing <- unique(namez_existing$id_kc_pha)
-    
-    # If using the same seed as was used to create other IDs, can just tack on
-    # the number of new IDs needed
-    ids_final <- id_nodups(id_n = length(ids_existing) + new_ids_needed,
-                           id_length = 10)
-    
-    ids_final_dedup <- ids_final[!ids_final %in% ids_existing]
-    
-    # Make sure there are enough new IDs
-    if (length(ids_final_dedup) < new_ids_needed) {
-      # Run again but make it longer
-      ids_final <- id_nodups(id_n = length(ids_existing) + new_ids_needed * 3,
-                             id_length = 10)
-      
-      ids_final_dedup <- ids_final[!ids_final %in% ids_existing]
-      rm(ids_final_dedup)
-    }
-    # Check again
-    if (length(ids_final_dedup) < new_ids_needed) {
-      stop("Could not generate enough new IDs")
-    }
-    
-    # Trim to correct size
-    ids_final <- ids_final_dedup[1:new_ids_needed]
-  } else {
-    ids_final <- id_nodups(id_n = new_ids_needed, id_length = 10)
-  }
-  
-  # Join to cluster IDs
-  ids_final <- ids_dedup %>%
-    distinct(cluster_final) %>%
-    arrange(cluster_final) %>%
-    bind_cols(., id_kc_pha = ids_final)
-  
-  # Join to make final list of names and IDs
-  namez_final <- namez_use %>%
-    select(ssn, pha_id, lname, fname, mname, dob, female, id_hash) %>%
-    left_join(., select(ids_dedup, id_hash, cluster_final), by = "id_hash") %>%
-    left_join(., ids_final, by = "cluster_final") %>%
-    select(-cluster_final) %>%
-    distinct() %>%
-    mutate(last_run = Sys.time())
-  
-  
-  ## Consolidate IDs ----
-  if (exists("namez_existing")) {
-    # Easiest to assign a number to each ID so taking the min works to consolidate groups
-    # Quicker to use data table to set these up
-    namez_existing <- setDT(namez_existing)
-    setnames(namez_existing, "id_kc_pha", "id_kc_pha_old")
-    namez_existing[, `:=` (hash_cnt_old = .N, id_num_old = .GRP), by = "id_kc_pha_old"]
-    
-    namez_final <- setDT(rename(namez_final, id_kc_pha_new = id_kc_pha))
-    namez_final[, `:=` (hash_cnt_new = .N, id_num_new = .GRP), by = "id_kc_pha_new"]
-    namez_final[, id_num_new := id_num_new + length(ids_existing)]
-    
-    # Bring old and new together
-    namez_dedup <- merge(namez_existing[, .(id_hash, id_kc_pha_old, hash_cnt_old, id_num_old)],
-                         namez_final[, .(id_hash, id_kc_pha_new, hash_cnt_new, id_num_new)],
-                         by = "id_hash", all = T)
-    
-    # Check for unclosed groups in either direction
-    namez_dedup[!is.na(id_kc_pha_old), id_min_new := min(id_num_new, na.rm = T), by = "id_kc_pha_old"]
-    namez_dedup[!is.na(id_kc_pha_new), id_min_old := min(id_num_old, na.rm = T), by = "id_kc_pha_new"]
-    
-    # Replace infinite values created above
-    namez_dedup[is.infinite(id_min_old), id_min_old := NA]
-    namez_dedup[is.infinite(id_min_new), id_min_new := NA]
-    
-    # Any rows with blank id_min_new and id_min_old are those that didn't match at all. Just bring over id_num_new
-    namez_dedup[is.na(id_min_new) & is.na(id_min_old), id_min_new := id_num_new]
-    
-    # Consolidate so old number is preferentially kept
-    namez_dedup[, id_num_final := coalesce(id_min_old, id_min_new)]
-    
-    # Make a reshaped list of IDs and ID numbers to get final ID
-    id_num_list <- bind_rows(distinct(namez_dedup, id_kc_pha_old, id_num_old) %>% 
-                               filter(!is.na(id_kc_pha_old)) %>%
-                               rename(id_kc_pha_final = id_kc_pha_old,
-                                      id_num_final = id_num_old),
-                             distinct(namez_dedup, id_kc_pha_new, id_num_new) %>% 
-                               rename(id_kc_pha_final = id_kc_pha_new, 
-                                      id_num_final = id_num_new))
-    
-    # Check the number of IDs matches what is expected
-    if (nrow(id_num_list) != length(ids_existing) + new_ids_needed) {
-      stop("Mismatched number of rows in id_num_list (too many or too few)")
-    }
-    
-    # Join to get the final ID
-    namez_dedup <- left_join(select(namez_dedup, id_hash, id_kc_pha_old, id_kc_pha_new, id_num_final),
-                             id_num_list,
-                             by = "id_num_final") %>%
-      select(-id_num_final)
-    
-    
-    ## Make final names table ----
-    # Set up last_run time
+        
+# TIDY THE LINKAGE TABLE ----
+    # linkages <- linkages[agency != 'Neither'] # if I do this, I will drop all the linkages to the Exit and Waitlist data too
+    linkages[, pha_id := kcha_id]
+    linkages[is.na(pha_id), pha_id := sha_id] # replace with sha_id if there is not kcha_id. This is arbitrary
     run_time <- Sys.time()
-    namez_final <- left_join(namez_final, 
-                             select(namez_dedup, id_hash, id_kc_pha_final),
-                             by = "id_hash") %>%
-      select(ssn, pha_id, lname, fname, mname, dob, female, id_hash, id_kc_pha_final) %>%
-      rename(id_kc_pha = id_kc_pha_final) %>%
-      mutate(last_run = run_time)
+    linkages <- unique(linkages[, .(ssn, pha_id, lname, fname, mname, dob, female, id_hash, KCMASTER_ID, last_run = run_time)])
     
-    
-    # UPDATE ID TABLE ----
+    # As of 8/31/2023, there were a couple of times when a single id_hash was liked to > 1 KCMASTER_ID ... this should not be!
+    linkages <- linkages[!duplicated(id_hash), ]
+
+    setorder(linkages, lname, fname, mname, na.last = T)
+        
+# UPDATE stage_identities_history TABLE ----
     # Want to keep a record of a person's ID over time
-    # Assumes a table called [final_schema].[final_table]_history exists
-    # Could make a dynamic part of a function later
-    
+    # There are five potential components to the updated history table
+    # hx1 = historic data where the id_hash no longer exists in the new linkage table (unlikely, but anything is possible!)
+    # hx2 = new id_hash with their corresponding KCMASTER_ID
+    # hx3 = changed previously (pairs of id_hash and KCMASTER_ID previously designated no longer valid)
+    # hx4 = change current (pairs of id_hash and KCMASTER_ID that are no longer valid)
+    # hx5 = unchanged current (pairs of id_hash and KCMASTER_ID that remain the same as the previous run)
+
     # Bring in history table
-    id_history <- dbGetQuery(
+    id_history <- setDT(dbGetQuery(
       db_hhsaw, glue_sql("SELECT * FROM {`final_schema`}.{DBI::SQL(paste0(final_table, '_history'))}",
-                         .con = db_hhsaw))
+                         .con = db_hhsaw)))
+    id_history.count <- nrow(copy(id_history))
+    
     # Fix any format issues
-    id_history <- id_history %>%
-      mutate(across(c("from_date", "to_date", "last_run"), ~ as.POSIXct(.)))
+    id_history[, c("from_date", "to_date", "last_run") := lapply(.SD, as.POSIXct), .SDcols = c("from_date", "to_date", "last_run")]
+
+    # get hx1 (historic data where the id_hash is no longer in the current linkage data)
+    hx1 <- id_history[!id_hash %in% linkages$id_hash]
+    id_history <- fsetdiff(id_history, hx1)
+    hx1[!is.na(id_kc_pha) & is.na(KCMASTER_ID) & is.na(to_date), # only needed when first after transition to KCMASTER_ID
+        to_date := as.POSIXct(run_time, origin = "1970-01-01", tz = "utc")]
     
+    # get hx2 (new id_hash that do not exist in historic data)
+    hx2 <- linkages[!id_hash %in% id_history$id_hash]
+    hx2 <- hx2[, .(id_hash, KCMASTER_ID, id_kc_pha = NA_character_, 
+                   from_date = as.POSIXct(run_time, origin = "1970-01-01", tz = "utc"), 
+                   to_date = NA_POSIXct_, last_run = NA_POSIXct_)]
     
-    # Find IDs that changed and update their to_date
-    id_changed <- namez_dedup %>% 
-      filter(!is.na(id_kc_pha_old) & id_kc_pha_old != id_kc_pha_final) %>%
-      select(id_hash) %>%
-      mutate(changed = 1L)
+    # get hx3 (ID pairings that already have a to_date (i.e., were previously changed))
+    hx3 <- id_history[!is.na(to_date)]
+    id_history <- id_history[is.na(to_date)]
     
-    id_history_updated <- left_join(id_history, id_changed, by = "id_hash") %>%
-      mutate(to_date = as.POSIXct(ifelse(changed == 1, run_time, to_date), origin = "1970-01-01", tz = "utc")) %>%
-      select(-changed)
+    # get hx4 & hx5 (hx4 = ID pairs that changed; hx5 = ID pairs that remained the same)
+    hx4_5 <- merge(linkages[, .(id_hash, KCMASTER_ID)], 
+                        id_history[, .(id_hash, KCMASTER_ID_old = KCMASTER_ID, id_kc_pha, to_date)], 
+                        by = 'id_hash', 
+                        all.x = F, 
+                        all.y = T)
     
-    # Add in new or changed IDs and set from date
-    id_new <- namez_dedup %>% 
-      filter(is.na(id_kc_pha_old) | id_kc_pha_old != id_kc_pha_final) %>%
-      select(id_hash, id_kc_pha_final) %>%
-      rename(id_kc_pha = id_kc_pha_final) %>%
-      mutate(from_date = run_time, to_date = as.POSIXct(NA))
+    hx4_5[(KCMASTER_ID != KCMASTER_ID_old  & is.na(to_date))|
+                               (!is.na(id_kc_pha) & is.na(to_date)),  # only need this condition 1x > when switching from id_kc_pha to KCMASTER_ID
+                              changed := 1L]
     
-    id_history_updated <- bind_rows(id_history_updated, id_new)
+    hx4_5 <- hx4_5[, .(id_hash, KCMASTER_ID = KCMASTER_ID_old, id_kc_pha, changed)]
     
-    # Replace last_run date
-    id_history_updated <- id_history_updated %>%
-      mutate(last_run = lubridate::with_tz(run_time, tzone = "utc"))
+    hx4_5 <- merge(id_history, 
+                        hx4_5, 
+                        by = c('id_hash', 'KCMASTER_ID', 'id_kc_pha'), 
+                        all = T)
     
-  }
-  
+    hx4_5[changed == 1, to_date := as.POSIXct(run_time, origin = "1970-01-01", tz = "utc")]
+    hx4_5[, changed := NULL]
+    
+    # Create updated history table
+    history_updated <- rbind(hx1, hx2, hx3, hx4_5)
+    history_updated[, last_run := as.POSIXct(run_time, origin = "1970-01-01", tz = "utc")]
+    
+    # Quick QA
+    if(nrow(history_updated) == id_history.count + nrow(hx2)){ # new table should have all rows from old table plus new IDs
+      message('\U0001f642 ... all rows from the pre-existing history table are accounted for.')
+    } else {stop("\n\U0001f47f ... there is a problem in the construction of your new history table. The total rows are not what was expected.")}
+
 # QA FINAL DATA ----
-  # Number of id_hashes compared to the number of id_kc_phas
-  message("There are ", n_distinct(namez_final$id_hash), " IDs and ", 
-          n_distinct(namez_final$id_kc_pha), " id_kc_phas")
-  
-  
-  ## Check that the combined pha.stage_identifies table is longer than the the previous time ----
-      ident_cnt_prev <- as.integer(
-        dbGetQuery(db_hhsaw,
-                   glue_sql("SELECT qa_result
-                            FROM ", {paste0(qa_schema, '.', qa_table)}, "
-                            WHERE table_name = {paste0(to_schema, '.', to_table)} 
-                              AND qa_type = 'value' 
-                              AND qa_item = 'row_count' 
-                              AND qa_date = (
-                                SELECT MAX(qa_date) 
-                                FROM ", {paste0(qa_schema, '.', qa_table)}, " 
+    # Check number of id_hashes compared to the number of KCMASTER_ID ----
+        message("There are ", format(n_distinct(linkages$id_hash), big.mark = ','), " IDs and ", 
+                format(n_distinct(linkages$KCMASTER_ID), big.mark = ','), " KCMASTER_IDs")
+    
+    # Check that the combined pha.stage_identifies table is longer than the the previous time ----
+        ident_cnt_prev <- as.integer(
+          dbGetQuery(db_hhsaw,
+                     glue_sql("SELECT qa_result
+                                FROM ", {paste0(qa_schema, '.', qa_table)}, "
                                 WHERE table_name = {paste0(to_schema, '.', to_table)} 
                                   AND qa_type = 'value' 
-                                  AND qa_item = 'row_count')", .con = db_hhsaw)
-        ))
-  
-      if (is.na(ident_cnt_prev)) {
-        qa_row_diff_result <- "PASS"
-        qa_row_diff_note <- glue("There was no existing row data to compare to last time")
-        message(paste("\U0001f642", qa_row_diff_note))
-      } else if (!is.na(ident_cnt_prev) & nrow(namez_final) >= ident_cnt_prev) {
-        qa_row_diff_result <- "PASS"
-        qa_row_diff_note <- glue("There are {format(nrow(namez_final) - ident_cnt_prev, big.mark = ',')}", 
-                                 " more rows in the latest stage_identities table")
-        message(paste("\U0001f642", qa_row_diff_note))
-      } else if (!is.na(ident_cnt_prev) & nrow(namez_final) < ident_cnt_prev) {
-        qa_row_diff_result <- "FAIL"
-        qa_row_diff_note <- glue("There were {format(ident_cnt_prev - nrow(namez_final), big.mark = ',')}", 
-                                 " fewer rows in the latest stage_identities table. See why this is.")
-        warning(paste("\U00026A0", qa_row_diff_note))
-      } 
-      
-      DBI::dbExecute(db_hhsaw,
-                     glue_sql("INSERT INTO {`qa_schema`}.{`qa_table`} 
-                                (etl_batch_id, last_run, table_name, qa_type, qa_item, qa_result, qa_date, note) 
-                                VALUES (NULL, {min(namez_final$last_run)}, '{DBI::SQL(to_schema)}.{DBI::SQL(to_table)}', 'result', 
-                                'row_count_vs_previous', {qa_row_diff_result}, {Sys.time()}, {qa_row_diff_note})",
-                              .con = db_hhsaw))
-  
-  ## Check that number of unique id_kc_pha is greater than in the previous time ----
-      pha_ID_cnt_prev <- as.integer(
-        dbGetQuery(db_hhsaw,
-                   glue_sql("SELECT qa_result
-                            FROM ", {paste0(qa_schema, '.', qa_table)}, "
-                            WHERE table_name = {paste0(to_schema, '.', to_table)} 
-                              AND qa_type = 'value' 
-                              AND qa_item = 'id_count' 
-                              AND qa_date = (
-                                SELECT MAX(qa_date) 
-                                FROM ", {paste0(qa_schema, '.', qa_table)}, " 
+                                  AND qa_item = 'row_count' 
+                                  AND qa_date = (
+                                    SELECT MAX(qa_date) 
+                                    FROM ", {paste0(qa_schema, '.', qa_table)}, " 
+                                    WHERE table_name = {paste0(to_schema, '.', to_table)} 
+                                      AND qa_type = 'value' 
+                                      AND qa_item = 'row_count')", .con = db_hhsaw)
+          ))
+        
+        if (is.na(ident_cnt_prev)) {
+          qa_row_diff_result <- "PASS"
+          qa_row_diff_note <- glue("There was no existing row data to compare to last time")
+          message(paste("\U0001f642", qa_row_diff_note))
+        } else if (!is.na(ident_cnt_prev) & nrow(linkages) >= ident_cnt_prev) {
+          qa_row_diff_result <- "PASS"
+          qa_row_diff_note <- glue("There are {format(nrow(linkages) - ident_cnt_prev, big.mark = ',')}", 
+                                   " more rows in the latest stage_identities table")
+          message(paste("\U0001f642", qa_row_diff_note))
+        } else if (!is.na(ident_cnt_prev) & nrow(linkages) < ident_cnt_prev) {
+          qa_row_diff_result <- "FAIL"
+          qa_row_diff_note <- glue("There were {format(ident_cnt_prev - nrow(linkages), big.mark = ',')}", 
+                                   " fewer rows in the latest stage_identities table. See why this is.")
+          warning(paste("\U00026A0", qa_row_diff_note))
+        } 
+        
+        DBI::dbExecute(db_hhsaw,
+                       glue_sql("INSERT INTO {`qa_schema`}.{`qa_table`} 
+                                    (etl_batch_id, last_run, table_name, qa_type, qa_item, qa_result, qa_date, note) 
+                                    VALUES (NULL, {min(linkages$last_run)}, '{DBI::SQL(to_schema)}.{DBI::SQL(to_table)}', 'result', 
+                                    'row_count_vs_previous', {qa_row_diff_result}, {Sys.time()}, {qa_row_diff_note})",
+                                .con = db_hhsaw))
+    
+    # Check that number of unique KCMASTER_ID is greater than in the previous time ----
+        pha_ID_cnt_prev <- as.integer(
+          dbGetQuery(db_hhsaw,
+                     glue_sql("SELECT qa_result
+                                FROM ", {paste0(qa_schema, '.', qa_table)}, "
                                 WHERE table_name = {paste0(to_schema, '.', to_table)} 
                                   AND qa_type = 'value' 
-                                  AND qa_item = 'id_count')", .con = db_hhsaw)
-        ))
+                                  AND qa_item = 'id_count' 
+                                  AND qa_date = (
+                                    SELECT MAX(qa_date) 
+                                    FROM ", {paste0(qa_schema, '.', qa_table)}, " 
+                                    WHERE table_name = {paste0(to_schema, '.', to_table)} 
+                                      AND qa_type = 'value' 
+                                      AND qa_item = 'id_count')", .con = db_hhsaw)
+          ))
+        
+        if (is.na(pha_ID_cnt_prev)) {
+          qa_id_diff_result <- "PASS"
+          qa_id_diff_note <- glue("There was no existing count of uniue IDs in stage_identities to compare to last time")
+          message(paste("\U0001f642", qa_id_diff_note))
+        } else if (!is.na(pha_ID_cnt_prev) & uniqueN(linkages$KCMASTER_ID) >= pha_ID_cnt_prev) {
+          qa_id_diff_result <- "PASS"
+          qa_id_diff_note <- glue("There are {format(uniqueN(linkages$KCMASTER_ID) - pha_ID_cnt_prev, big.mark = ',')}", 
+                                  " more unique KCMASTER_ID in the latest stage_identities table")
+          message(paste("\U0001f642", qa_id_diff_note))
+        } else if (!is.na(pha_ID_cnt_prev) & uniqueN(linkages$KCMASTER_ID) < pha_ID_cnt_prev) {
+          qa_id_diff_result <- "FAIL"
+          qa_id_diff_note <- glue("There were {format(pha_ID_cnt_prev - uniqueN(linkages$KCMASTER_ID), big.mark = ',')}", 
+                                  " fewer unique KCMASTER_ID in the latest stage_identities table. See why this is.")
+          warning(paste("\U00026A0", qa_id_diff_note))
+        } 
+        
+        DBI::dbExecute(db_hhsaw,
+                       glue_sql("INSERT INTO {`qa_schema`}.{`qa_table`} 
+                                    (etl_batch_id, last_run, table_name, qa_type, qa_item, qa_result, qa_date, note) 
+                                    VALUES (NULL, {min(linkages$last_run)}, '{DBI::SQL(to_schema)}.{DBI::SQL(to_table)}', 'result', 
+                                    'id_count_vs_previous', {qa_id_diff_result}, {Sys.time()}, {qa_id_diff_note})",
+                                .con = db_hhsaw))
       
-      if (is.na(pha_ID_cnt_prev)) {
-        qa_id_diff_result <- "PASS"
-        qa_id_diff_note <- glue("There was no existing count of uniue IDs in stage_identities to compare to last time")
-        message(paste("\U0001f642", qa_id_diff_note))
-      } else if (!is.na(pha_ID_cnt_prev) & uniqueN(namez_final$id_kc_pha) >= pha_ID_cnt_prev) {
-        qa_id_diff_result <- "PASS"
-        qa_id_diff_note <- glue("There are {format(uniqueN(namez_final$id_kc_pha) - pha_ID_cnt_prev, big.mark = ',')}", 
-                                 " more unique id_kc_pha in the latest stage_identities table")
-        message(paste("\U0001f642", qa_id_diff_note))
-      } else if (!is.na(pha_ID_cnt_prev) & uniqueN(namez_final$id_kc_pha) < pha_ID_cnt_prev) {
-        qa_id_diff_result <- "FAIL"
-        qa_id_diff_note <- glue("There were {format(pha_ID_cnt_prev - uniqueN(namez_final$id_kc_pha), big.mark = ',')}", 
-                                 " fewer unique id_kc_pha in the latest stage_identities table. See why this is.")
-        warning(paste("\U00026A0", qa_id_diff_note))
-      } 
-      
-      DBI::dbExecute(db_hhsaw,
-                     glue_sql("INSERT INTO {`qa_schema`}.{`qa_table`} 
-                                (etl_batch_id, last_run, table_name, qa_type, qa_item, qa_result, qa_date, note) 
-                                VALUES (NULL, {min(namez_final$last_run)}, '{DBI::SQL(to_schema)}.{DBI::SQL(to_table)}', 'result', 
-                                'id_count_vs_previous', {qa_id_diff_result}, {Sys.time()}, {qa_id_diff_note})",
-                              .con = db_hhsaw))
-      
-  
-  
 # ADD VALUES TO METADATA ----
     # Row counts
     DBI::dbExecute(db_hhsaw,
                    glue_sql("INSERT INTO {`qa_schema`}.{`qa_table`} 
                             (etl_batch_id, last_run, table_name, 
                               qa_type, qa_item, qa_result, qa_date, note) 
-                            VALUES (NULL, {min(namez_final$last_run)}, 
+                            VALUES (NULL, {min(linkages$last_run)}, 
                                     '{DBI::SQL(to_schema)}.{DBI::SQL(to_table)}',
-                                    'value', 'row_count', {nrow(namez_final)},
+                                    'value', 'row_count', {nrow(linkages)},
                                     {Sys.time()}, NULL)",
                             .con = db_hhsaw))
     
@@ -764,9 +314,9 @@
                    glue_sql("INSERT INTO {`qa_schema`}.{`qa_table`} 
                             (etl_batch_id, last_run, table_name, 
                               qa_type, qa_item, qa_result, qa_date, note) 
-                            VALUES (NULL, {min(namez_final$last_run)}, 
+                            VALUES (NULL, {min(linkages$last_run)}, 
                                     '{DBI::SQL(to_schema)}.{DBI::SQL(to_table)}',
-                                    'value', 'id_count', {n_distinct(namez_final$id_kc_pha)},
+                                    'value', 'id_count', {n_distinct(linkages$KC_MASTERID)},
                                     {Sys.time()}, NULL)",
                             .con = db_hhsaw))
   
@@ -783,22 +333,22 @@
     # Split into smaller tables to avoid SQL db_hhsaw connection issues
     start <- 1L
     max_rows <- 50000L
-    cycles <- ceiling(nrow(namez_final)/max_rows)
+    cycles <- ceiling(nrow(linkages)/max_rows)
     
     lapply(seq(start, cycles), function(i) {
       start_row <- ifelse(i == 1, 1L, max_rows * (i-1) + 1)
-      end_row <- min(nrow(namez_final), max_rows * i)
+      end_row <- min(nrow(linkages), max_rows * i)
       
       message("Loading cycle ", i, " of ", cycles)
       if (i == 1) {
         dbWriteTable(db_hhsaw,
                      name = DBI::Id(schema = to_schema, table = to_table),
-                     value = as.data.frame(namez_final[start_row:end_row, ]),
+                     value = as.data.frame(linkages[start_row:end_row, ]),
                      overwrite = T, append = F)
       } else {
         dbWriteTable(db_hhsaw,
                      name = DBI::Id(schema = to_schema, table = to_table),
-                     value = as.data.frame(namez_final[start_row:end_row ,]),
+                     value = as.data.frame(linkages[start_row:end_row ,]),
                      overwrite = F, append = T)
       }
     })
@@ -807,22 +357,22 @@
     # Split into smaller tables to avoid SQL db_hhsaw connection issues
     start <- 1L
     max_rows <- 50000L
-    cycles <- ceiling(nrow(id_history_updated)/max_rows)
+    cycles <- ceiling(nrow(history_updated)/max_rows)
     
     lapply(seq(start, cycles), function(i) {
       start_row <- ifelse(i == 1, 1L, max_rows * (i-1) + 1)
-      end_row <- min(nrow(id_history_updated), max_rows * i)
+      end_row <- min(nrow(history_updated), max_rows * i)
       
       message("Loading cycle ", i, " of ", cycles)
       if (i == 1) {
         dbWriteTable(db_hhsaw,
                      name = DBI::Id(schema = to_schema, table = paste0(to_table, "_history")),
-                     value = as.data.frame(id_history_updated[start_row:end_row, ]),
+                     value = as.data.frame(history_updated[start_row:end_row, ]),
                      overwrite = T, append = F)
       } else {
         dbWriteTable(db_hhsaw,
                      name = DBI::Id(schema = to_schema, table = paste0(to_table, "_history")),
-                     value = as.data.frame(id_history_updated[start_row:end_row ,]),
+                     value = as.data.frame(history_updated[start_row:end_row ,]),
                      overwrite = F, append = T)
       }
     })

--- a/etl/stage/load_stage_pha_identities.R
+++ b/etl/stage/load_stage_pha_identities.R
@@ -316,7 +316,7 @@
                               qa_type, qa_item, qa_result, qa_date, note) 
                             VALUES (NULL, {min(linkages$last_run)}, 
                                     '{DBI::SQL(to_schema)}.{DBI::SQL(to_table)}',
-                                    'value', 'id_count', {n_distinct(linkages$KC_MASTERID)},
+                                    'value', 'id_count', {n_distinct(linkages$KCMASTER_ID)},
                                     {Sys.time()}, NULL)",
                             .con = db_hhsaw))
   

--- a/etl/stage/load_stage_pha_timevar.yaml
+++ b/etl/stage/load_stage_pha_timevar.yaml
@@ -1,0 +1,39 @@
+datasource: PHA
+schema: pha
+table: stage_timevar
+vars: 
+    KCMASTER_ID: NVARCHAR(24)
+    id_hash: NVARCHAR(130)
+    hh_id_long: INT
+    hh_KCMASTER_ID: NVARCHAR(24)
+    from_date: DATE
+    to_date: DATE
+    cov_time: INT
+    gap_length: INT
+    gap: BIT
+    period: INT
+    period_start: DATE
+    period_end: DATE
+    disability: INT
+    agency: NVARCHAR(10)
+    major_prog: NVARCHAR(8)
+    subsidy_type: NVARCHAR(46)
+    prog_type: NVARCHAR(8)
+    operator_type: NVARCHAR(34)
+    vouch_type_final: NVARCHAR(60)
+    agency_prog_concat: NVARCHAR(196)
+    geo_add1_clean: NVARCHAR(88)
+    geo_add2_clean: NVARCHAR(30)
+    geo_city_clean: NVARCHAR(42)
+    geo_state_clean: NVARCHAR(6)
+    geo_zip_clean: NVARCHAR(12)
+    geo_hash_clean: NVARCHAR(130)
+    geo_blank: BIT
+    geo_kc_area: BIT
+    property_id: NVARCHAR(18)
+    portfolio_final: NVARCHAR(128)
+    port_in: BIT
+    port_out_kcha: BIT
+    port_out_sha: BIT
+    cost_pha: NVARCHAR(12)
+    last_run: DATETIME

--- a/etl/stage/qa_stage_pha_demo.R
+++ b/etl/stage/qa_stage_pha_demo.R
@@ -137,7 +137,7 @@ qa_stage_pha_demo <- function(conn = NULL,
   
   refresh <- data.table(table_name = paste0(to_schema, '.', to_table), 
                         qa_item = 'row_count', 
-                        qa_value = row_count, 
+                        qa_value = as.integer(row_count), 
                         qa_date = Sys.time(), 
                         note = 'Count after refresh')
   update_qa(myupdate = refresh, mytable = qa_values)


### PR DESCRIPTION
Previously used RecordLinkage package to create `id_kc_pha` as a unique identifier across PHAs
Now use `KCMASTER_ID` from IDH [IDMatch].[IM_HISTORY_TABLE] instead
updated code for identities, demo, timevar, and calyear tables